### PR TITLE
Purchase and product indexes

### DIFF
--- a/app/admin/items.rb
+++ b/app/admin/items.rb
@@ -1,0 +1,21 @@
+ActiveAdmin.register Item do
+  permit_params :name, :price, :image
+
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :price
+    column :image_url
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :price
+      f.input :image, as: :file
+    end
+    f.actions
+  end
+end

--- a/app/admin/purchases.rb
+++ b/app/admin/purchases.rb
@@ -1,0 +1,21 @@
+ActiveAdmin.register Purchase do
+  permit_params :status
+
+  includes :item, :user
+
+  index do
+    selectable_column
+    id_column
+    column :item
+    column :user
+    tag_column :status
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :status
+    end
+    f.actions
+  end
+end

--- a/app/controllers/app/items_controller.rb
+++ b/app/controllers/app/items_controller.rb
@@ -1,3 +1,5 @@
 class App::ItemsController < App::BaseController
-  def index; end
+  def index
+    @items = Item.all
+  end
 end

--- a/app/controllers/app/purchases_controller.rb
+++ b/app/controllers/app/purchases_controller.rb
@@ -1,3 +1,5 @@
 class App::PurchasesController < App::BaseController
-  def index; end
+  def index
+    @purchases = current_user.purchases.order(created_at: :desc).includes(:item)
+  end
 end

--- a/app/javascript/api/items.ts
+++ b/app/javascript/api/items.ts
@@ -1,0 +1,7 @@
+export interface Item {
+  id: number;
+  name: string;
+  description: string;
+  price: number;
+  image: Record<string, Record<'url', string>>;
+}

--- a/app/javascript/api/purchases.ts
+++ b/app/javascript/api/purchases.ts
@@ -1,0 +1,23 @@
+import api from './index';
+import type { User } from './users';
+import type { Item } from './items';
+
+export interface Purchase {
+  id: number;
+  user: User;
+  item: Item;
+}
+
+export default {
+  create(itemId: number) {
+    const path = '/api/internal/purchases';
+
+    return api({
+      method: 'post',
+      url: path,
+      data: {
+        purchase: { itemId },
+      },
+    });
+  },
+};

--- a/app/javascript/api/purchases.ts
+++ b/app/javascript/api/purchases.ts
@@ -4,6 +4,7 @@ import type { Item } from './items';
 
 export interface Purchase {
   id: number;
+  status: 'pending' | 'delivered';
   user: User;
   item: Item;
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,6 +7,7 @@ import BaseButton from './components/base-button.vue';
 import BaseCheckbox from './components/base-checkbox.vue';
 import UserSession from './components/user-session.vue';
 import ItemList from './components/item-list.vue';
+import PurchaseList from './components/purchase-list.vue';
 import './css/application.css';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -15,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
       TheHeader,
       UserSession,
       ItemList,
+      PurchaseList,
       BaseNotifications,
     },
   });

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,7 @@
 import { createApp } from 'vue';
+import Notifications from '@kyvg/vue3-notification';
 import TheHeader from './components/the-header.vue';
+import BaseNotifications from './components/base-notifications.vue';
 import BaseInput from './components/base-input.vue';
 import BaseButton from './components/base-button.vue';
 import BaseCheckbox from './components/base-checkbox.vue';
@@ -13,11 +15,13 @@ document.addEventListener('DOMContentLoaded', () => {
       TheHeader,
       UserSession,
       ItemList,
+      BaseNotifications,
     },
   });
   app.component('BaseInput', BaseInput);
   app.component('BaseButton', BaseButton);
   app.component('BaseCheckbox', BaseCheckbox);
+  app.use(Notifications);
   app.mount('#vue-app');
 
   return app;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,7 @@ import BaseInput from './components/base-input.vue';
 import BaseButton from './components/base-button.vue';
 import BaseCheckbox from './components/base-checkbox.vue';
 import UserSession from './components/user-session.vue';
+import ItemList from './components/item-list.vue';
 import './css/application.css';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -11,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
     components: {
       TheHeader,
       UserSession,
+      ItemList,
     },
   });
   app.component('BaseInput', BaseInput);

--- a/app/javascript/components/base-notifications.vue
+++ b/app/javascript/components/base-notifications.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <notifications
+    :duration="-1"
+    width="auto"
+  />
+</template>
+
+<style scoped lang="scss">
+::v-deep .vue-notification {
+  @apply font-base text-sm;
+
+  &.success {
+    @apply bg-green-400 border-l-green-600;
+  }
+
+  &.error {
+    @apply bg-rose-400 border-l-rose-600;
+  }
+}
+</style>

--- a/app/javascript/components/item-list-card.vue
+++ b/app/javascript/components/item-list-card.vue
@@ -1,18 +1,36 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { useNotification } from '@kyvg/vue3-notification';
+import purchasesApi from '../api/purchases';
 
 type Props = {
+  itemId: number
   name: string
   price: number
   imageUrl: string
 };
 const props = defineProps<Props>();
+
 const currencyFormatter = new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' });
 const formattedPrice = computed(() => currencyFormatter.format(props.price));
+
+const loading = ref(false);
+const { notify } = useNotification();
+async function buy() {
+  loading.value = true;
+  try {
+    await purchasesApi.create(props.itemId);
+    notify({ text: 'Genial, recibimos tu orden! Te contactaremos para coordinar', type: 'success' });
+  } catch (error) {
+    notify({ text: 'Ups, ocurrió un error! Inténtalo de nuevo', type: 'error' });
+  } finally {
+    loading.value = false;
+  }
+}
 </script>
 
 <template>
-  <div class="flex w-80 flex-col gap-4 overflow-hidden rounded-lg bg-white shadow-md">
+  <div class="flex w-80 flex-col items-center gap-4 overflow-hidden rounded-lg bg-white shadow-md">
     <img
       :src="imageUrl"
       alt="Product image"
@@ -26,7 +44,11 @@ const formattedPrice = computed(() => currencyFormatter.format(props.price));
         {{ name }}
       </span>
     </div>
-    <button class="w-full py-4 text-blue-800">
+    <button
+      class="w-full py-4 text-blue-800 disabled:text-zinc-500"
+      :disabled="loading"
+      @click="buy"
+    >
       Comprar
     </button>
   </div>

--- a/app/javascript/components/item-list-card.vue
+++ b/app/javascript/components/item-list-card.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+type Props = {
+  name: string
+  price: number
+  imageUrl: string
+};
+const props = defineProps<Props>();
+const currencyFormatter = new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' });
+const formattedPrice = computed(() => currencyFormatter.format(props.price));
+</script>
+
+<template>
+  <div class="flex w-80 flex-col gap-4 overflow-hidden rounded-lg bg-white shadow-md">
+    <img
+      :src="imageUrl"
+      alt="Product image"
+      class="w-full"
+    >
+    <div class="flex flex-col gap-2 text-center text-zinc-800">
+      <span class="text-xl font-bold">
+        {{ formattedPrice }}
+      </span>
+      <span>
+        {{ name }}
+      </span>
+    </div>
+    <button class="w-full py-4 text-blue-800">
+      Comprar
+    </button>
+  </div>
+</template>

--- a/app/javascript/components/item-list.vue
+++ b/app/javascript/components/item-list.vue
@@ -14,6 +14,7 @@ defineProps<Props>();
       <item-list-card
         v-for="item in items"
         :key="item.id"
+        :item-id="item.id"
         :name="item.name"
         :price="item.price"
         :image-url="item.image['sm']['url']"

--- a/app/javascript/components/item-list.vue
+++ b/app/javascript/components/item-list.vue
@@ -9,16 +9,14 @@ defineProps<Props>();
 </script>
 
 <template>
-  <div class="flex flex-col justify-center py-16">
-    <div class="mx-auto grid grid-cols-2 gap-12">
-      <item-list-card
-        v-for="item in items"
-        :key="item.id"
-        :item-id="item.id"
-        :name="item.name"
-        :price="item.price"
-        :image-url="item.image['sm']['url']"
-      />
-    </div>
+  <div class="mx-auto grid grid-cols-2 gap-12">
+    <item-list-card
+      v-for="item in items"
+      :key="item.id"
+      :item-id="item.id"
+      :name="item.name"
+      :price="item.price"
+      :image-url="item.image['sm']['url']"
+    />
   </div>
 </template>

--- a/app/javascript/components/item-list.vue
+++ b/app/javascript/components/item-list.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { Item } from '../api/items';
+import ItemListCard from './item-list-card.vue';
+
+type Props = {
+  items: Item[]
+};
+defineProps<Props>();
+</script>
+
+<template>
+  <div class="flex flex-col justify-center py-16">
+    <div class="mx-auto grid grid-cols-2 gap-12">
+      <item-list-card
+        v-for="item in items"
+        :key="item.id"
+        :name="item.name"
+        :price="item.price"
+        :image-url="item.image['sm']['url']"
+      />
+    </div>
+  </div>
+</template>

--- a/app/javascript/components/purchase-list-card.vue
+++ b/app/javascript/components/purchase-list-card.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+type Props = {
+  itemName: string
+  status: 'pending' | 'delivered'
+};
+defineProps<Props>();
+const tagColorClasses = {
+  pending: 'bg-yellow-50 border border-yellow-500 text-yellow-500',
+  delivered: 'bg-green-50 border border-green-500 text-green-500',
+};
+const tagText = {
+  pending: 'En proceso',
+  delivered: 'Entregado',
+};
+</script>
+
+<template>
+  <div class="flex w-full items-center justify-between rounded-md bg-white px-4 py-3 shadow-md">
+    <span class="text-zinc-800">{{ itemName }}</span>
+    <div
+      :class="tagColorClasses[status]"
+      class="rounded-md px-2 py-0.5 font-medium"
+    >
+      {{ tagText[status] }}
+    </div>
+  </div>
+</template>

--- a/app/javascript/components/purchase-list.vue
+++ b/app/javascript/components/purchase-list.vue
@@ -9,14 +9,12 @@ defineProps<Props>();
 </script>
 
 <template>
-  <div class="mx-auto flex max-w-screen-md flex-col items-center py-16">
-    <div class="flex w-full flex-col gap-y-4">
-      <purchase-list-card
-        v-for="purchase in purchases"
-        :key="purchase.id"
-        :item-name="purchase.item.name"
-        :status="purchase.status"
-      />
-    </div>
+  <div class="flex w-full flex-col gap-y-4">
+    <purchase-list-card
+      v-for="purchase in purchases"
+      :key="purchase.id"
+      :item-name="purchase.item.name"
+      :status="purchase.status"
+    />
   </div>
 </template>

--- a/app/javascript/components/purchase-list.vue
+++ b/app/javascript/components/purchase-list.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { Purchase } from '../api/purchases';
+import PurchaseListCard from './purchase-list-card.vue';
+
+type Props = {
+  purchases: Purchase[]
+};
+defineProps<Props>();
+</script>
+
+<template>
+  <div class="mx-auto flex max-w-screen-md flex-col items-center py-16">
+    <div class="flex w-full flex-col gap-y-4">
+      <purchase-list-card
+        v-for="purchase in purchases"
+        :key="purchase.id"
+        :item-name="purchase.item.name"
+        :status="purchase.status"
+      />
+    </div>
+  </div>
+</template>

--- a/app/javascript/components/the-header.vue
+++ b/app/javascript/components/the-header.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 interface Props {
-  signedIn: string
+  signedIn: boolean
 }
 defineProps<Props>();
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2,6 +2,8 @@ class Purchase < ApplicationRecord
   belongs_to :user
   belongs_to :item
 
+  enum status: { pending: 0, delivered: 1 }
+
   delegate :name, to: :item, prefix: true
 end
 
@@ -14,6 +16,7 @@ end
 #  item_id    :bigint(8)        not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  status     :integer          default("pending"), not null
 #
 # Indexes
 #

--- a/app/serializers/api/internal/purchase_serializer.rb
+++ b/app/serializers/api/internal/purchase_serializer.rb
@@ -6,6 +6,7 @@ class Api::Internal::PurchaseSerializer < ActiveModel::Serializer
 
   attributes(
     :id,
+    :status,
     :created_at,
     :updated_at
   )

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -10,8 +10,8 @@ class ImageUploader < BaseUploader
   plugin :image_handling_utilities
 
   DERIVATIVES = {
-    sm: { size: [300, 300], resize_method: 'resize_to_fill!', type: 'jpg' },
-    sm_webp: { size: [300, 300], resize_method: 'resize_to_fill!', type: 'webp' }
+    sm: { size: [320, 320], resize_method: 'resize_to_fill!', type: 'jpg' },
+    sm_webp: { size: [320, 320], resize_method: 'resize_to_fill!', type: 'webp' }
   }
 
   Attacher.derivatives do |original|

--- a/app/views/app/items/index.html.erb
+++ b/app/views/app/items/index.html.erb
@@ -1,1 +1,2 @@
-Index items
+<item-list :items="<%= serialize_resource(@items) %>">
+</item-list>

--- a/app/views/app/purchases/index.html.erb
+++ b/app/views/app/purchases/index.html.erb
@@ -1,1 +1,2 @@
-Index compras
+<purchase-list :purchases="<%= serialize_resource(@purchases) %>">
+</purchase-list>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
         :signed-in="<%= current_user.present? %>"
       >
       </the-header>
-      <div class="container mx-auto">
+      <div class="container mx-auto max-w-screen-md flex flex-col items-center py-16">
         <base-notifications></base-notifications>
         <%= yield %>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
       >
       </the-header>
       <div class="container mx-auto">
+        <base-notifications></base-notifications>
         <%= yield %>
       </div>
     </div>

--- a/db/migrate/20221215145239_add_status_to_purchases.rb
+++ b/db/migrate/20221215145239_add_status_to_purchases.rb
@@ -1,0 +1,5 @@
+class AddStatusToPurchases < ActiveRecord::Migration[6.1]
+  def change
+    add_column :purchases, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_21_151037) do
+ActiveRecord::Schema.define(version: 2022_12_15_145239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2022_11_21_151037) do
     t.bigint "item_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
     t.index ["item_id"], name: "index_purchases_on_item_id"
     t.index ["user_id"], name: "index_purchases_on_user_id"
   end

--- a/lib/fake_data_loader.rb
+++ b/lib/fake_data_loader.rb
@@ -59,7 +59,7 @@ module FakeDataLoader
     10.times do
       create(
         :item,
-        image: URI.parse(Faker::LoremFlickr.image).open
+        image: URI.parse(Faker::LoremFlickr.image(search_terms: ['furniture'])).open
       )
     end
   end

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@babel/preset-env": "7",
     "@babel/runtime": "7",
     "@fortawesome/fontawesome-free": "^6.2.1",
+    "@kyvg/vue3-notification": "^2.7.0",
     "@rails/ujs": "^7.0.4",
     "@tailwindcss/forms": "^0.5.3",
     "@types/humps": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,6 +1325,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@kyvg/vue3-notification@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@kyvg/vue3-notification/-/vue3-notification-2.7.0.tgz#2264d0244853b4cfc6a1aa4f2bfc508891d471a9"
+  integrity sha512-Eti6jRGips9fpf2WdRjlOOJGyjCZ35qt84CeTeFr5piAwXaMpvgzea4dqqTK5KCfqK3qz/zwwxAd/8AToLYL8A==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"


### PR DESCRIPTION
### Contexto

App de juguete para onboarding trainees

### Qué se esta haciendo

Se agrega el estado inicial que tendría el index de compras y de productos:
- En el index de productos, cada card tiene un botón que crea una compra. Esto gatilla un post por api y una notificación
- El index de compras es más simple y no tiene interactividad

#### En particular hay que revisar

Una duda específica que tengo:
En el figma trabajé con container `md`, y como la clase `container` da un espacio mayor, tuve que en ambas vistas centrar y/o limitar con `mx-w-screen-md`. Les parece bien? Debería estar limitado así quizás a nivel del layout?

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)

[Figma](https://www.figma.com/file/TUBICpcfyhq9ZkNRXTwJhx/Proyecto-Trainees---Tienda-de-muebles?node-id=183%3A1902&t=J0NG3IIHVPoMieSA-0)

![localhost_3000_ (1)](https://user-images.githubusercontent.com/12057523/207902383-55c927f4-4f65-4e27-bb0c-db567f4c6ceb.png)
-----
![localhost_3000_purchases (1)](https://user-images.githubusercontent.com/12057523/207903462-8ebf3042-f38c-43d8-980b-2402d1f39081.png)