### PR TITLE
feat(db): add Review model to db

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,27 @@
+class Review < ApplicationRecord
+  belongs_to :users
+  belongs_to :items
+end
+
+# == Schema Information
+#
+# Table name: reviews
+#
+#  id         :bigint(8)        not null, primary key
+#  users_id   :bigint(8)        not null
+#  items_id   :bigint(8)        not null
+#  rating     :integer
+#  body       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_reviews_on_items_id  (items_id)
+#  index_reviews_on_users_id  (users_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (items_id => items.id)
+#  fk_rails_...  (users_id => users.id)
+#

--- a/db/migrate/20221226125913_create_reviews.rb
+++ b/db/migrate/20221226125913_create_reviews.rb
@@ -1,0 +1,12 @@
+class CreateReviews < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reviews do |t|
+      t.references :users, null: false, foreign_key: true
+      t.references :items, null: false, foreign_key: true
+      t.integer :rating
+      t.string :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_15_145239) do
+ActiveRecord::Schema.define(version: 2022_12_26_125913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,17 @@ ActiveRecord::Schema.define(version: 2022_12_15_145239) do
     t.index ["user_id"], name: "index_purchases_on_user_id"
   end
 
+  create_table "reviews", force: :cascade do |t|
+    t.bigint "users_id", null: false
+    t.bigint "items_id", null: false
+    t.integer "rating"
+    t.string "body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["items_id"], name: "index_reviews_on_items_id"
+    t.index ["users_id"], name: "index_reviews_on_users_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -77,4 +88,6 @@ ActiveRecord::Schema.define(version: 2022_12_15_145239) do
 
   add_foreign_key "purchases", "items"
   add_foreign_key "purchases", "users"
+  add_foreign_key "reviews", "items", column: "items_id"
+  add_foreign_key "reviews", "users", column: "users_id"
 end

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :review do
+    users { nil }
+    items { nil }
+    rating { 1 }
+    body { "MyString" }
+  end
+end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Review, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### Contexto

El problema es el siguiente: se necesita crear un nuevo modelo Review, que relaciona un usuario con un producto. Con los siguientes atributos:
- user_id
- item_id
- body

[Ver enunciado](https://www.notion.so/platanus/Agregar-reviews-a-los-productos-e55e8851b1a342b7a1b65dbffd8b91fa)

### Qué se esta haciendo

Al inicio se corrieron las migraciones pendientes con `bin/rails db:schema:load`. Posteriormente para crear el modelo se uso el comando `bin/rails generate model Review users:references items:references body:string`. Se corrieron las migraciones con `db:migrate` y se checkearon si estaban todas bien con `db:migrate:status`.

#### En particular hay que revisar

Si la creacion del modelo fue correcta y con tiene los atributos necesarios.

